### PR TITLE
Btrfs subvols

### DIFF
--- a/backend/src/install_service.rs
+++ b/backend/src/install_service.rs
@@ -280,7 +280,7 @@ fn install_target(request: &InstallSystemRequest, progress: &(dyn Fn(String) + S
     // write boot entries into a directory nothing ever reads.
     let mounts = resolve_mounts(&request.mounts)?;
 
-    // If this is a btrfs root, create the @/@/home subvolumes
+    // If this is a btrfs root, create the @/@home subvolumes
     if let Some(root) = mounts
         .iter()
         .find(|mount| mount.mountpoint == "/" && mount.subvol.is_some())

--- a/backend/src/install_service.rs
+++ b/backend/src/install_service.rs
@@ -4,12 +4,14 @@
 
 //! Install service: privileged operations for installing the target system
 
-use crate::auth::AuthService;
+pub mod btrfs;
+
+use crate::{auth::AuthService, install_service::btrfs::is_btrfs};
 use disks::BlockDevice;
 use lichen_macros::authorized;
 use protocols::lichen::install::{
-    DiscoverSystemModelsResponse, DiscoveredModel, InstallProgress, InstallSystemRequest, WriteSystemModelRequest,
-    WriteSystemModelResponse,
+    DiscoverSystemModelsResponse, DiscoveredModel, InstallProgress, InstallSystemRequest, TargetMount,
+    WriteSystemModelRequest, WriteSystemModelResponse,
     install_server::{Install, InstallServer},
 };
 use std::{
@@ -60,6 +62,15 @@ const UNSTABLE_REPO: &str = r#"unstable {
 #[derive(Debug)]
 pub struct Service {
     auth: Arc<AuthService>,
+}
+
+/// A target mount resolved to its on-disk filesystem type, with a btrfs root
+/// expanded into its @ (root) and @home subvolumes.
+struct ResolvedMount {
+    device: String,
+    mountpoint: String,
+    fstype: String,
+    subvol: Option<String>,
 }
 
 /// Creates a new Install gRPC server instance using the default Service implementation
@@ -178,7 +189,17 @@ fn write_to_target(root_device: &str, system_model: &str, install_model: &str) -
 
     fs::create_dir_all(target)?;
 
-    run(Command::new("mount").args([root_device, target.to_str().expect("expected a target")]))?;
+    // The model must land where the OS will: for btrfs that's the @ subvolume,
+    // not the top level, which the installed system never mounts.
+    let mut mount = Command::new("mount");
+
+    if is_btrfs(root_device)? {
+        btrfs::create_subvolumes(target, root_device)?;
+        mount.args(["-o", &format!("subvol={}", btrfs::ROOT_SUBVOL)]);
+    }
+
+    mount.arg(root_device).arg(target);
+    run(&mut mount)?;
 
     let result = (|| -> Result<(), Status> {
         let system_model_path = target.join(SYSTEM_MODEL_PATH);
@@ -257,8 +278,15 @@ fn install_target(request: &InstallSystemRequest, progress: &(dyn Fn(String) + S
     // Sort by path length so a parent is always mounted before its children:
     // mounting /boot after /boot/efi would shadow the ESP, and blsforme would
     // write boot entries into a directory nothing ever reads.
-    let mut mounts = request.mounts.clone();
-    mounts.sort_by_key(|mount| mount.mountpoint.len());
+    let mounts = resolve_mounts(&request.mounts)?;
+
+    // If this is a btrfs root, create the @/@/home subvolumes
+    if let Some(root) = mounts
+        .iter()
+        .find(|mount| mount.mountpoint == "/" && mount.subvol.is_some())
+    {
+        btrfs::create_subvolumes(target, &root.device)?;
+    }
 
     let mut mounted: Vec<PathBuf> = Vec::new();
     let result = (|| -> Result<(), Status> {
@@ -266,7 +294,14 @@ fn install_target(request: &InstallSystemRequest, progress: &(dyn Fn(String) + S
         for mount in &mounts {
             let mountpoint = target.join(mount.mountpoint.trim_start_matches('/'));
             fs::create_dir_all(&mountpoint)?;
-            run(Command::new("mount").args([&mount.device, &mountpoint.to_string_lossy().into()]))?;
+
+            let mut cmd = Command::new("mount");
+
+            if let Some(subvol) = &mount.subvol {
+                cmd.args(["-o", &format!("subvol={subvol}")]);
+            }
+            cmd.arg(&mount.device).arg(&mountpoint);
+            run(&mut cmd)?;
             mounted.push(mountpoint);
         }
 
@@ -549,22 +584,22 @@ fn run(command: &mut Command) -> Result<(), Status> {
 /// any non-zero pass drops the boot into emergency mode on a healthy
 /// filesystem. vfat carries no UNIX permissions, so without an explicit
 /// umask the ESP and XBOOTLDR contents are world readable.
-fn fstab_params(mountpoint: &str, fstype: &str) -> (&'static str, u8) {
-    match (mountpoint, fstype) {
+fn fstab_params(mountpoint: &str, fstype: &str, subvol: Option<&str>) -> (String, u8) {
+    let (base, pass) = match (mountpoint, fstype) {
+        (_, "btrfs") => ("defaults", 0u8),
         ("/", "bcachefs") => ("defaults", 0),
         ("/", _) => ("defaults", 1),
         (_, "vfat") => ("defaults,umask=0077", 0),
         _ => ("defaults", 2),
+    };
+    match subvol {
+        Some(subvol) => (format!("{base},subvol={subvol}"), pass),
+        None => (base.to_string(), pass),
     }
 }
 
-fn write_fstab(target: &Path, req: &InstallSystemRequest) -> Result<(), Status> {
-    let mut mounts = req
-        .mounts
-        .iter()
-        .filter(|mount| mount.mountpoint.starts_with('/'))
-        .collect::<Vec<_>>();
-    mounts.sort_by_key(|mount| mount.mountpoint.len());
+fn write_fstab(target: &Path, request: &InstallSystemRequest) -> Result<(), Status> {
+    let mounts = resolve_mounts(&request.mounts)?;
 
     // A rootless fstable is worse than none: the initrd hands off to a system
     // that can neither remount / nor find /boot.
@@ -576,15 +611,38 @@ fn write_fstab(target: &Path, req: &InstallSystemRequest) -> Result<(), Status> 
 
     for mount in mounts {
         let partuuid = blkid(&mount.device, "PARTUUID")?;
-        let fstype = blkid(&mount.device, "TYPE")?;
-        let (options, pass) = fstab_params(&mount.mountpoint, &fstype);
+        let (options, pass) = fstab_params(&mount.mountpoint, &mount.fstype, mount.subvol.as_deref());
 
         fstab.push_str(&format!(
-            "PARTUUID={partuuid} {} {fstype} {options} 0 {pass}\n",
-            mount.mountpoint
+            "PARTUUID={partuuid} {} {} {options} 0 {pass}\n",
+            mount.mountpoint, mount.fstype
         ));
     }
 
     fs::write(target.join("etc/fstab"), fstab)?;
     Ok(())
+}
+
+/// Probe each requested mount's filesystem and expand a btrfs root into the
+/// default @/@home subvolume layout. Sorted so parents precede children.
+fn resolve_mounts(mounts: &[TargetMount]) -> Result<Vec<ResolvedMount>, Status> {
+    let mut resolved = Vec::new();
+
+    for mount in mounts {
+        if !mount.mountpoint.starts_with('/') {
+            continue;
+        }
+        resolved.push(ResolvedMount {
+            device: mount.device.clone(),
+            mountpoint: mount.mountpoint.clone(),
+            fstype: blkid(&mount.device, "TYPE")?,
+            subvol: None,
+        });
+    }
+
+    // Checks to see if it's a btrfs filesystem. If it is, it creates @/@home, if it
+    // isn't it's a no-op function.
+    btrfs::expand_subvolumes(&mut resolved);
+    resolved.sort_by_key(|mount| mount.mountpoint.len());
+    Ok(resolved)
 }

--- a/backend/src/install_service/btrfs.rs
+++ b/backend/src/install_service/btrfs.rs
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: Copyright © 2026 AerynOS Developers
+//
+// SPDX-License-Identifier: MPL-2.0
+
+//! btrfs specific install handling: the default @/@home subvolume layout.
+
+use super::{blkid, run};
+use crate::install_service::ResolvedMount;
+use std::{path::Path, process::Command};
+use tonic::Status;
+
+pub(super) const ROOT_SUBVOL: &str = "@";
+pub(super) const HOME_SUBVOL: &str = "@home";
+
+/// Rewrite a btrfs root into the default @/@home layout: the root ("/") mount
+/// moves onto @ and a /home mount on @home is derived from the same device.
+/// No-op unless the root mount is btrfs, non-btrfs installs pass through untouched.
+pub(super) fn expand_subvolumes(mounts: &mut Vec<ResolvedMount>) {
+    let Some(root) = mounts
+        .iter_mut()
+        .find(|mount| mount.mountpoint == "/" && mount.fstype == "btrfs")
+    else {
+        return;
+    };
+
+    root.subvol = Some(ROOT_SUBVOL.to_string());
+    let device = root.device.clone();
+    let fstype = root.fstype.clone();
+
+    // Only derive /home if dedicated /home mount isn't already present
+    if !mounts.iter().any(|mount| mount.mountpoint == "/home") {
+        mounts.push(ResolvedMount {
+            device,
+            mountpoint: "/home".to_string(),
+            fstype,
+            subvol: Some(HOME_SUBVOL.to_string()),
+        });
+    }
+}
+
+/// True if the device holds a btrfs filesystem.
+pub(super) fn is_btrfs(device: &str) -> Result<bool, Status> {
+    Ok(blkid(device, "TYPE")? == "btrfs")
+}
+
+/// Mount a freshly-formatted btrfs root, create the @ and @home subvolumes,
+/// then unmount so the real subvolume mounts can take over.
+pub(super) fn create_subvolumes(target: &Path, device: &str) -> Result<(), Status> {
+    run(Command::new("mount").args(["-o", "subvolid=5"]).arg(device).arg(target))?;
+
+    let result = (|| -> Result<(), Status> {
+        for subvol in [ROOT_SUBVOL, HOME_SUBVOL] {
+            let path = target.join(subvol);
+            if !path.exists() {
+                run(Command::new("btrfs").args(["subvolume", "create"]).arg(path))?;
+            }
+        }
+        run(Command::new("btrfs")
+            .args(["subvolume", "set-default"])
+            .arg(target.join(ROOT_SUBVOL)))?;
+        Ok(())
+    })();
+
+    let _ = run(Command::new("umount").arg(target));
+    result
+}

--- a/cli/src/frontend/storage.rs
+++ b/cli/src/frontend/storage.rs
@@ -317,10 +317,41 @@ pub fn render_plan(plan: &StrategyPlan) -> String {
     }
 
     if !plan.role_mounts.is_empty() {
+        // The @/@home layout is applied backend-side for the btrfs root, so it
+        // isn't in the role_mounts; reconstruct it here for the preview.
+        let root_device = plan
+            .role_mounts
+            .iter()
+            .find(|role_mount| role_mount.mountpoint == "/")
+            .map(|role_mount| role_mount.device.as_str());
+        let root_btrfs = root_device.is_some_and(|device| {
+            plan.filesystems.iter().any(|plan_fs| {
+                plan_fs.device == device
+                    && plan_fs
+                        .filesystem
+                        .as_ref()
+                        .is_some_and(|filesystem| filesystem.filesystem_type == "btrfs")
+            })
+        });
+        let has_home = plan
+            .role_mounts
+            .iter()
+            .any(|role_mount| role_mount.mountpoint == "/home");
+
         out.push_str("\nMounts:\n");
         plan.role_mounts.iter().for_each(|role_mount| {
-            out.push_str(&format!("  {} <- {}\n", role_mount.mountpoint, role_mount.device));
+            if root_btrfs && role_mount.mountpoint == "/" {
+                out.push_str(&format!("  / <- {} (subvol=@)\n", role_mount.device));
+            } else {
+                out.push_str(&format!("  {} <- {}\n", role_mount.mountpoint, role_mount.device));
+            }
         });
+
+        if root_btrfs && !has_home {
+            if let Some(device) = root_device {
+                out.push_str(&format!("  /home <- {device} (subvol=@home)\n"));
+            }
+        }
     }
 
     out

--- a/data/strategies/use_whole_disk.kdl
+++ b/data/strategies/use_whole_disk.kdl
@@ -173,7 +173,7 @@ strategy name="whole_disk_btrfs" summary="Wipe and use entire disk" {
         constraints {
             min (GiB)25
         }
-        type (GUID)"linux-fs"
+        type (GUID)"linux-root"
         filesystem {
             type "btrfs"
             label "ROOT"

--- a/data/strategies/use_whole_disk.kdl
+++ b/data/strategies/use_whole_disk.kdl
@@ -12,7 +12,7 @@ strategy name="whole_disk_xfs" summary="Wipe and use entire disk" {
     create-partition-table type="gpt" disk="root_disk"
     
     // 256 MiB ESP plus 3840 MiB XBOOTLDR is a flat 4 GiB of boot space, fixed
-    // rather than ranged so every instal has identical room for several
+    // rather than ranged so every install has identical room for several
     // kernels and initrds regardless of disk size.
 
     // Create the ESP


### PR DESCRIPTION
# Summary
  
Make the default btrfs root install onto the standard @/@home subvolume layout instead of a flat filesystem: / on @, /home on @home. The whole layout is integrated backend-side; no proto, KDL, or disks-rs changes. Non-btrfs installs are untouched.
  
## Additions
  
- New `install_service/btrfs.rs` submodule holds the btrfs-specific logic so it stays out of the generic install path:
  - `expand_subvolumes` rewrites a btrfs root mount onto @ and derives a /home mount on @home from the same device when no dedicated /home mount previously exists.
  - `create_subvolumes mounts the fresh filesystem at the top level (-o subvolid=5), creates @ and @home, and runs `btrfs subvolume set-default @`.
  - `is_btrfs` probes the device's filesystem type.
- `resolve_mounts` replaces the ad-hoc mount sort: it probes each requested mount's on-disk type with blkid, runs btrfs::expand_subvolumes, and sorts so parents mount before children. A non-btrfs mount keeps subvol = None and behaves exactly as before.
- Both write paths land content in @, never the top-level subvolume the installed system never mounts:
  - `write_to_target` creates the subvolumes and mounts subvol=@ before writing the system-model, so moss finds the model where the OS will.
  - `install_target` creates the subvolumes, then mounts each resolved mount with its `subvol=` option.
- fstab generation carries the subvolumes: `fstab_params` now takes a `subvol` and appends `subvol=@`/`subvol=@home`; / and /home share the PARTUUID, and btrfs gets pass 0.
  - **NOTE**: `create_subvolumes` mounts with `subvol=5` on purpose; it runs on both write paths, and after `set-default @` a plain mount would land inside `@` and create a nested `@/@`. Pinning subvolid=5 always hits the top level.
  - **NOTE**: `set-default @` is required. During `moss -D target` install blsforme emits a bare `root=UUID=` with no `rootfsflags=subvol=`, so without a default subvolume the kernel mounts the top level (no /usr) and drops into emergency mode.
- The `whole_disk_btrfs` strategy stamps the Linux Root (x86_64) GUID (linux-root) on the root partition, matching the bcachefs strategy.
- The CLI install summary reconstructs the @/@home layout for the preview (/ <- dev (subvol=@) and append `/home -< dev (subvol=@home)`), since the subvolumes are enabled backend-side and aren't in role_mounts.