### PR TITLE
Delete: .github/FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-# These are supported funding model platforms
-
-github: [ikeycode]


### PR DESCRIPTION
Rebased on current [upstream](https://github.com/aerynos/lichen-installer) with .github/FUNDING.yaml removed.